### PR TITLE
Fixed target platform

### DIFF
--- a/bundles/org.palladiosimulator.textual.tpcm/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.textual.tpcm/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.xtext,
  org.palladiosimulator.pcm;bundle-version="4.2.0",
  org.eclipse.e4.core.di;bundle-version="1.7.400",
  org.eclipse.xtext.builder;bundle-version="2.22.0",
- org.palladiosimulator.textual.commons.generator;bundle-version="1.0.0"
+ org.palladiosimulator.textual.commons.generator;bundle-version="1.0.0",
+ org.eclipse.uml2.codegen.ecore;bundle-version="2.5.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: org.apache.log4j
 Export-Package: org.palladiosimulator.textual.tpcm,

--- a/releng/org.palladiosimulator.textual.targetplatform/org.palladiosimulator.textual.targetplatform.target
+++ b/releng/org.palladiosimulator.textual.targetplatform/org.palladiosimulator.textual.targetplatform.target
@@ -41,6 +41,10 @@
 <unit id="tools.mdsd.library.standalone.initialization.core.feature.feature.group" version="tbd"/>
 <repository location="https://updatesite.mdsd.tools/library-standaloneinitialization/nightly/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="tools.mdsd.license.epl2.feature.group" version="1.0.0"/>
+<repository location="https://updatesite.mdsd.tools/build-licensefeature/releases/1.0.0/"/>
+</location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit" filter="release" refresh="true">
 <unit id="tools.mdsd.ecoreworkflow.mwe2lib.xtext" version="0.1.0"/>
 <repository location="http://updatesite.mdsd.tools/ecore-workflow/releases/latest"/>


### PR DESCRIPTION
Standalone initializer introduced a dependency to the mdsd tools license feature. Furthermore, since the latest changes to StoEx, the uml2 codegen is not reexported anymore.